### PR TITLE
fix: selection area showing gray tint instead of original colors

### DIFF
--- a/shotshot/Features/Capture/SelectionOverlay.swift
+++ b/shotshot/Features/Capture/SelectionOverlay.swift
@@ -41,7 +41,7 @@ final class SelectionOverlayWindow: NSWindow {
 
         self.level = .screenSaver
         self.isOpaque = false
-        self.backgroundColor = NSColor.black.withAlphaComponent(0.3)
+        self.backgroundColor = .clear
         self.ignoresMouseEvents = false
         self.acceptsMouseMovedEvents = true
         self.hasShadow = false


### PR DESCRIPTION
## Summary
- Fixed selection overlay showing a gray tint over the selected area during screen capture
- The issue was caused by NSWindow's backgroundColor being set to semi-transparent black, which remained visible even when the view used .clear compositing operation
- Changed window backgroundColor to .clear so the overlay is drawn entirely by the view

## Test plan
- [ ] Run the app and capture a screenshot by dragging to select a region
- [ ] Verify the selected area shows the original screen colors without any gray tint
- [ ] Verify the area outside the selection still shows the dark overlay