### PR TITLE
fix: orphan window appearing after video save dialog

### DIFF
--- a/shotshot/Services/VideoExporter.swift
+++ b/shotshot/Services/VideoExporter.swift
@@ -53,7 +53,12 @@ struct VideoExporter {
         formatPicker.action = #selector(FormatPickerTarget.formatChanged(_:))
         FormatPickerTarget.shared.panel = panel
 
-        let response = await panel.beginSheetModal(for: NSApp.keyWindow ?? NSApp.mainWindow ?? NSWindow())
+        // シートではなく独立したダイアログとして表示（親ウィンドウがない場合の問題を回避）
+        let response = await withCheckedContinuation { continuation in
+            panel.begin { response in
+                continuation.resume(returning: response)
+            }
+        }
 
         guard response == .OK, let url = panel.url else {
             // キャンセル時は一時ファイル削除


### PR DESCRIPTION
## Summary
- Fixed a black rounded rectangle window appearing at the bottom-left after closing the video save dialog
- The issue was caused by creating an empty `NSWindow()` as a fallback parent for `beginSheetModal` when no key/main window existed
- Changed to use `begin()` instead to show as an independent dialog

## Test plan
- [ ] Start a screen recording
- [ ] Stop recording and complete/cancel the save dialog
- [ ] Verify no orphan window remains on screen