### PR TITLE
fix: replace Japanese comment with English

### DIFF
--- a/shotshot/Services/VideoExporter.swift
+++ b/shotshot/Services/VideoExporter.swift
@@ -53,7 +53,7 @@ struct VideoExporter {
         formatPicker.action = #selector(FormatPickerTarget.formatChanged(_:))
         FormatPickerTarget.shared.panel = panel
 
-        // シートではなく独立したダイアログとして表示（親ウィンドウがない場合の問題を回避）
+        // Show as independent dialog to avoid orphan window when no parent window exists
         let response = await withCheckedContinuation { continuation in
             panel.begin { response in
                 continuation.resume(returning: response)


### PR DESCRIPTION
## Summary
- Replace Japanese comment with English in VideoExporter.swift
- Follow the project rule: all code comments must be written in English

## Test plan
- No functional changes, comment-only fix