### PR TITLE
fix: ensure recording indicator badge is visible for narrow selections

### DIFF
--- a/shotshot/Features/Recording/RecordingIndicatorWindow.swift
+++ b/shotshot/Features/Recording/RecordingIndicatorWindow.swift
@@ -14,12 +14,14 @@ final class RecordingIndicatorWindow {
         let padding: CGFloat = 4
         let badgeHeight: CGFloat = 32
         let badgeGap: CGFloat = 8
+        let minBadgeWidth: CGFloat = 150  // Minimum width for badge (REC + time + stop button)
 
-        // 赤枠は選択領域の外側に表示
+        // Ensure window is wide enough for the badge
+        let frameWidth = max(selectionRect.width + padding * 2, minBadgeWidth)
         let frameRect = NSRect(
             x: selectionRect.origin.x - padding,
             y: selectionRect.origin.y - padding - badgeHeight - badgeGap,
-            width: selectionRect.width + padding * 2,
+            width: frameWidth,
             height: selectionRect.height + padding * 2 + badgeHeight + badgeGap
         )
 


### PR DESCRIPTION
## Summary
- Added minimum width (150px) for the recording indicator window
- Ensures the badge (REC label, time, stop button) is always visible even when the selection area is very narrow

## Test plan
- [ ] Start a recording with a very narrow selection area (e.g., 50px wide)
- [ ] Verify the stop button and time display are fully visible