### PR TITLE
fix: use logical size instead of physical pixels for recording

### DIFF
--- a/shotshot/Features/Recording/RecordingManager.swift
+++ b/shotshot/Features/Recording/RecordingManager.swift
@@ -68,12 +68,11 @@ final class RecordingManager: NSObject {
         let tempURL = tempDir.appendingPathComponent(UUID().uuidString).appendingPathExtension("mp4")
         self.tempFileURL = tempURL
 
-        // AVAssetWriter の構成
+        // AVAssetWriter configuration (use logical size, not physical pixels)
         let writer = try AVAssetWriter(outputURL: tempURL, fileType: .mp4)
 
-        let scaleFactor = Int(selection.scaleFactor)
-        let videoWidth = Int(selection.rect.width) * scaleFactor
-        let videoHeight = Int(selection.rect.height) * scaleFactor
+        let videoWidth = Int(selection.rect.width)
+        let videoHeight = Int(selection.rect.height)
 
         let videoSettings: [String: Any] = [
             AVVideoCodecKey: AVVideoCodecType.h264,


### PR DESCRIPTION
## Summary
- On Retina displays, recordings were twice the expected size due to scaleFactor being applied
- Now uses logical size (selection area size) instead of physical pixels
- Results in smaller, more reasonable file sizes

**Note:** This PR should be merged after #8.

## Test plan
- [ ] On a Retina display, record a 200x200 selection area
- [ ] Verify the resulting video is 200x200, not 400x400