### PR TITLE
Add launch at login setting

### DIFF
--- a/shotshot/Features/Settings/SettingsView.swift
+++ b/shotshot/Features/Settings/SettingsView.swift
@@ -36,6 +36,8 @@ struct GeneralSettingsView: View {
 
                 Toggle("settings.copy_to_clipboard", isOn: $viewModel.copyToClipboard)
 
+                Toggle("settings.launch_at_login", isOn: $viewModel.launchAtLogin)
+
                 HStack {
                     Text("settings.timer_seconds")
                     Stepper(value: $viewModel.timerSeconds, in: 1...10) {

--- a/shotshot/Features/Settings/SettingsViewModel.swift
+++ b/shotshot/Features/Settings/SettingsViewModel.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Carbon
 import Foundation
+import ServiceManagement
 import SwiftUI
 
 extension Notification.Name {
@@ -19,6 +20,20 @@ final class SettingsViewModel {
 
     var copyToClipboard: Bool {
         didSet { settings.copyToClipboard = copyToClipboard }
+    }
+
+    var launchAtLogin: Bool {
+        didSet {
+            do {
+                if launchAtLogin {
+                    try SMAppService.mainApp.register()
+                } else {
+                    try SMAppService.mainApp.unregister()
+                }
+            } catch {
+                launchAtLogin = !launchAtLogin
+            }
+        }
     }
 
     var timerSeconds: Int {
@@ -51,6 +66,7 @@ final class SettingsViewModel {
         self.savePath = settings.savePath
         self.copyToClipboard = settings.copyToClipboard
         self.timerSeconds = settings.timerSeconds
+        self.launchAtLogin = SMAppService.mainApp.status == .enabled
 
         let modifiers = settings.hotkeyModifiers
         self.useControl = modifiers & UInt32(NSEvent.ModifierFlags.control.rawValue) != 0

--- a/shotshot/Resources/en.lproj/Localizable.strings
+++ b/shotshot/Resources/en.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "settings.update_hotkey" = "Update Hotkey";
 "settings.hotkey_invalid" = "Invalid key.";
 "settings.hotkey_updated" = "Hotkey updated.";
+"settings.launch_at_login" = "Launch at login";
 
 /* Editor */
 "editor.line_width" = "Line width";

--- a/shotshot/Resources/ja.lproj/Localizable.strings
+++ b/shotshot/Resources/ja.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "settings.update_hotkey" = "ホットキーを更新";
 "settings.hotkey_invalid" = "無効なキーです";
 "settings.hotkey_updated" = "ホットキーを更新しました";
+"settings.launch_at_login" = "ログイン時に起動";
 
 /* Editor */
 "editor.line_width" = "太さ";


### PR DESCRIPTION
## Summary

- Adds a "Launch at login" toggle in General Settings
- Uses `SMAppService.mainApp` (macOS 13+) to register/unregister as a login item
- State is managed by the OS; read back on init via `SMAppService.mainApp.status`
- Localized in English and Japanese

## Test plan

- [ ] Open Settings > General and confirm "Launch at login" toggle appears
- [ ] Enable the toggle, log out and back in — ShotShot should launch automatically
- [ ] Disable the toggle, log out and back in — ShotShot should not launch
- [ ] Confirm toggle reflects current state correctly on app restart