### PR TITLE
Fix: exclude ShotShot's own windows from screenshot capture

### DIFF
--- a/shotshot/Features/Capture/CaptureManager.swift
+++ b/shotshot/Features/Capture/CaptureManager.swift
@@ -258,7 +258,9 @@ final class CaptureManager {
         }
         print("[CaptureManager] Found display: \(display.displayID)")
 
-        let filter = SCContentFilter(display: display, excludingWindows: [])
+        let ownBundleID = Bundle.main.bundleIdentifier ?? ""
+        let ownWindows = content.windows.filter { $0.owningApplication?.bundleIdentifier == ownBundleID }
+        let filter = SCContentFilter(display: display, excludingWindows: ownWindows)
 
         let scaleFactor = Int(selection.scaleFactor)
         let config = SCStreamConfiguration()


### PR DESCRIPTION
## Summary

- `SCContentFilter` was created with an empty `excludingWindows` array, so ShotShot's own windows could appear in captured screenshots during region selection
- Fix: filter `SCShareableContent.current.windows` by the app's bundle identifier and pass them as excluded windows to the content filter

## Test plan

- [ ] Take a region selection screenshot while ShotShot's settings window is open — it should not appear in the captured image
- [ ] Verify normal screenshots still work correctly